### PR TITLE
Prevent erroneous audit logs

### DIFF
--- a/artemis-prometheus-metrics-plugin-servlet/src/main/java/com/redhat/amq/broker/core/server/metrics/plugins/ArtemisPrometheusMetricsPluginServlet.java
+++ b/artemis-prometheus-metrics-plugin-servlet/src/main/java/com/redhat/amq/broker/core/server/metrics/plugins/ArtemisPrometheusMetricsPluginServlet.java
@@ -17,12 +17,14 @@
 
 package com.redhat.amq.broker.core.server.metrics.plugins;
 
+import javax.security.auth.Subject;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.Writer;
+import java.security.PrivilegedAction;
 import java.util.Set;
 
 import io.micrometer.core.instrument.MeterRegistry;
@@ -54,7 +56,7 @@ public class ArtemisPrometheusMetricsPluginServlet extends HttpServlet {
          resp.sendError(HttpServletResponse.SC_NOT_FOUND, "Prometheus meter registry is null. Has the Prometheus Metrics Plugin been configured?");
       } else {
          try (Writer writer = resp.getWriter()) {
-            writer.write(registry.scrape());
+            writer.write(Subject.doAs(new Subject(), (PrivilegedAction<String>)(() -> registry.scrape())));
             writer.flush();
          }
       }


### PR DESCRIPTION
ActiveMQ Artemis supports audit logs, which log all administrative actions that happen on the broker.
These logs identify the "current user" for an administrative access [by one of two methods](https://github.com/apache/activemq-artemis/blob/main/artemis-commons/src/main/java/org/apache/activemq/artemis/logs/AuditLogger.java#L67-L73):
1. The `Subject` associated with the current security manager context, or
2. A `ThreadLocal<Subject>`, which is set by JolokiaFilter as part of interaction with the admin console.

For a non-Artemis servlet such as the metrics plugin, this `ThreadLocal` is set to whatever `Subject` made the previous request on this thread. This leads to situations where metric accesses are logged as being done by ghost users.

This PR explicitly supplies an empty `Subject` for the scraping action.

To reproduce the issue:
1. Set up Artemis with the default admin/admin user and the metrics plugin.
2. Enable audit logging (`logger.audit_base` should be at `INFO` level)
3. Tail -f the audit log and start the server
4. Log in to the admin console
5. Observe that a lot of audit logs fly by for **admin(amq)@127.0.0.1**.
6. Access the metrics with eg `curl http://localhost:8161/metrics/`.
7. Observe that a lot of audit logs fly by for **admin(amq)@127.0.0.1**, even though these requests are completely anonymous.

After applying this patch, notice that the audit logs are for **anonymous@127.0.0.1**.