### PR TITLE
[#32] Set content-type to text/plain

### DIFF
--- a/artemis-prometheus-metrics-plugin-servlet/src/main/java/com/redhat/amq/broker/core/server/metrics/plugins/ArtemisPrometheusMetricsPluginServlet.java
+++ b/artemis-prometheus-metrics-plugin-servlet/src/main/java/com/redhat/amq/broker/core/server/metrics/plugins/ArtemisPrometheusMetricsPluginServlet.java
@@ -61,6 +61,7 @@ public class ArtemisPrometheusMetricsPluginServlet extends HttpServlet {
       } else {
          try {
             String output = registry.scrape();
+            resp.setContentType("text/plain");
             resp.setStatus(HttpServletResponse.SC_OK);
             try (Writer writer = resp.getWriter()) {
                writer.write(output);


### PR DESCRIPTION
Prometheus v3 is more strict concerning the Content-Type header received when scraping. Prometheus v2 would default to the standard Prometheus text protocol if the target being scraped did not specify a Content-Type header or if the header was unparsable or unrecognised. This could lead to incorrect data being parsed in the scrape. Prometheus v3 will now fail the scrape in such cases.

For further details see https://prometheus.io/docs/prometheus/3.0/migration/